### PR TITLE
use tutor package feature

### DIFF
--- a/courses/RascalShell/Commands/Set/Set.md
+++ b/courses/RascalShell/Commands/Set/Set.md
@@ -35,16 +35,16 @@ The options are:
 
 Turn `tracing` on and execute a function:
 ```rascal-shell
-import demo::basic::Factorial;
+import List;
 :set tracing true
-fac1(5)
+index(["a","b","c"])
 ```
 
 Turn trace off and execute the same function:
 
 ```rascal-shell,continue
 :set tracing false
-fac1(5)
+index(["a","b","c"])
 ```
 
 #### Benefits

--- a/courses/RascalShell/Commands/Test/Test.md
+++ b/courses/RascalShell/Commands/Test/Test.md
@@ -20,11 +20,7 @@ in the terminal.
 Execute the tests in an imported module:
 
 ```rascal-shell
-import demo::basic::Factorial;
-test
+import lang::rascal::tests::library::String;
+:test
 ```
 
-Execute the tests in the `Integers` module in the Rascal test suite:
-```rascal-shell
-test lang::rascal::tests::basic::Integers
-```

--- a/courses/Recipes/Languages/Func/LoadAST/LoadAST.md
+++ b/courses/Recipes/Languages/Func/LoadAST/LoadAST.md
@@ -55,7 +55,7 @@ We get the original program and its __abstract syntax tree__ of type `Prog` back
 In case of doubt, compare this with the result in ((Func-Parse)) where we did obtain a parse tree.
 Next, we try the same from a file:
 ```rascal-shell,continue
-load(|std:///demo/lang/Func/programs/F0.func|);
+load(|project://rascal-website/courses/Recipes/demo/lang/Func/programs/F0.func|);
 ```
 
 #### Benefits

--- a/courses/Recipes/Languages/Func/Parse/Parse.md
+++ b/courses/Recipes/Languages/Func/Parse/Parse.md
@@ -41,7 +41,7 @@ This must be defined as success: we get the original program and its parse tree 
 Next, we try the same from a file. We use the scheme `std` that refers to files that reside in the Rascal library.
 See ((Rascal:Values-Location)) for further details on other schemes.
 ```rascal-shell,continue
-parse(|std:///demo/lang/Func/programs/F0.func|);
+parse(|project://rascal-website/courses/Recipes/demo/lang/Func/programs/F0.func|);
 ```
 
 #### Benefits

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "mvn" : "mvn package",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <rascal.version>0.28.2</rascal.version>
-        <clair.version>0.6.3-SNAPSHOT</clair.version>
+        <clair.version>0.6.2</clair.version>
         <flybytes.version>0.1.3</flybytes.version>
         <rascal-maven-plugin.version>0.14.4</rascal-maven-plugin.version>
     </properties>
@@ -68,13 +68,13 @@
                                     <outputDirectory>${project.basedir}</outputDirectory>
                                     <includes>docs/**/*.*</includes>
                                 </artifactItem>
-                                <artifactItem>
+                                <!--                                <artifactItem>
                                     <groupId>org.rascalmpl</groupId>
                                     <artifactId>clair</artifactId>
                                     <version>${clair.version}</version>
                                     <outputDirectory>${project.basedir}</outputDirectory>
                                     <includes>docs/**/*.*</includes>
-                                </artifactItem>
+                                </artifactItem> -->
                                 <artifactItem>
                                     <groupId>org.rascalmpl</groupId>
                                     <artifactId>flybytes</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.rascalmpl</groupId>
-    <artifactId>website</artifactId>
+    <artifactId>rascal-website</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <repositories>
@@ -20,7 +20,8 @@
 
     <properties>
         <rascal.version>0.28.2</rascal.version>
-        <rascal-maven-plugin.version>0.13.2</rascal-maven-plugin.version>
+        <clair.version>0.6.3-SNAPSHOT</clair.version>
+        <rascal-maven-plugin.version>0.13.3-SNAPSHOT</rascal-maven-plugin.version>
     </properties>
 
     <build>
@@ -66,6 +67,13 @@
                                     <outputDirectory>${project.basedir}</outputDirectory>
                                     <includes>docs/**/*.*</includes>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.rascalmpl</groupId>
+                                    <artifactId>clair</artifactId>
+                                    <version>${clair.version}</version>
+                                    <outputDirectory>${project.basedir}</outputDirectory>
+                                    <includes>docs/**/*.*</includes>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -83,6 +91,7 @@
                             <goal>tutor</goal>
                         </goals>
                         <configuration>
+                            <isPackageCourse>false</isPackageCourse>
                             <enableStandardLibrary>true</enableStandardLibrary>
                             <errorsAsWarnings>false</errorsAsWarnings>
                             <bin>${project.basedir}</bin> <!-- because tutor appends /docs to this -->
@@ -133,6 +142,11 @@
             <groupId>org.rascalmpl</groupId>
             <artifactId>rascal</artifactId>
             <version>${rascal.version}</version>
+        </dependency>        
+        <dependency>
+            <groupId>org.rascalmpl</groupId>
+            <artifactId>clair</artifactId>
+            <version>${clair.version}</version>
         </dependency>        
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
     <properties>
         <rascal.version>0.28.2</rascal.version>
         <clair.version>0.6.3-SNAPSHOT</clair.version>
-        <rascal-maven-plugin.version>0.13.3-SNAPSHOT</rascal-maven-plugin.version>
+        <flybytes.version>0.1.3</flybytes.version>
+        <rascal-maven-plugin.version>0.14.4</rascal-maven-plugin.version>
     </properties>
 
     <build>
@@ -71,6 +72,13 @@
                                     <groupId>org.rascalmpl</groupId>
                                     <artifactId>clair</artifactId>
                                     <version>${clair.version}</version>
+                                    <outputDirectory>${project.basedir}</outputDirectory>
+                                    <includes>docs/**/*.*</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.rascalmpl</groupId>
+                                    <artifactId>flybytes</artifactId>
+                                    <version>${flybytes.version}</version>
                                     <outputDirectory>${project.basedir}</outputDirectory>
                                     <includes>docs/**/*.*</includes>
                                 </artifactItem>
@@ -147,6 +155,11 @@
             <groupId>org.rascalmpl</groupId>
             <artifactId>clair</artifactId>
             <version>${clair.version}</version>
+        </dependency>        
+        <dependency>
+            <groupId>org.rascalmpl</groupId>
+            <artifactId>flybytes</artifactId>
+            <version>${flybytes.version}</version>
         </dependency>        
     </dependencies>
 


### PR DESCRIPTION
- added clair with tutor package feature dependency
- bumped flybytes to 0.1.3
- fixed issues in Recipes caused by evolution of the standard library in version 0.28.2 of Rascal
