### PR TITLE
Improve SEO descriptions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,6 +20,9 @@ const config = {
   organizationName: 'usethesource', // Usually your GitHub org/user name.
   projectName: 'rascal-website', // Usually your repo name.
   deploymentBranch: 'gh-pages-v2',
+  customFields: {
+    description: 'The Rascal Meta Programming Language - The one-stop shop for metaprogramming',
+  },
   presets: [
     [
       'classic',
@@ -32,6 +35,8 @@ const config = {
           // `https://github.com/usethesource/rascal/tree/main/src/org/rascalmpl/courses/${docPath.substring(4)}`,
         },
         blog: {
+          blogTitle: 'Rascal MPL Blog',
+          blogDescription: 'Stories about using Rascal MPL in real life',
           showReadingTime: true,
           blogSidebarTitle: 'All posts',
           blogSidebarCount: 'ALL',

--- a/release-notes/index.mdx
+++ b/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Release Notes"
+title: "Rascal MPL - Release Notes"
+description: "Releases and changelogs for Rascal MPL"
 sidebar_position: 0
 ---
 
-On the left you can find all our (recent) release notes.
+On the left you can find all our (recent) release notes.xx

--- a/release-notes/index.mdx
+++ b/release-notes/index.mdx
@@ -4,4 +4,4 @@ description: "Releases and changelogs for Rascal MPL"
 sidebar_position: 0
 ---
 
-On the left you can find all our (recent) release notes.xx
+On the left you can find all our (recent) release notes.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -25,7 +25,7 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title}`}
-      description={`${siteConfig.description}`}>
+      description={`${siteConfig.customFields.description}`}>
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
As seen when pasting a link to rascal on Slack, our description was 'undefined'.

![image](https://github.com/usethesource/rascal-website/assets/609540/bffdaadf-b1f6-476a-b253-417988e0112b)

PR fixes some SEO fields.