### PR TITLE
Update Github Actions to JDK17

### DIFF
--- a/.github/workflows/base-jobs.yml
+++ b/.github/workflows/base-jobs.yml
@@ -14,7 +14,7 @@ jobs:
         - uses: actions/setup-java@v3
           with:
             distribution: 'temurin'
-            java-version: '11'
+            java-version: '17'
             cache: 'maven'
   
         - uses: actions/setup-node@v3


### PR DESCRIPTION
As part of the effort on https://github.com/usethesource/usethesource.github.io/issues/27 
Updated the action to use JDK17 for documentation building.