### PR TITLE
Increased logo size so that it's bigger than the subtitle

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,7 +22,7 @@
 }
 
 .hero__image {
-  height: 10rem;
+  height: 15rem;
 }
 
 .callout {


### PR DESCRIPTION
I thought the logo was a bit small in relation to the text below it, do you agree this is better?

Old:
![image](https://github.com/usethesource/rascal-website/assets/179603/0814b88e-793d-496b-bd22-be7aa71a1680)


New:
![image](https://github.com/usethesource/rascal-website/assets/179603/002b08f2-a5ca-4df2-bb60-d5265257cb19)
