### PR TITLE
Slicing out of bound modification

### DIFF
--- a/courses/Rascal/Expressions/Values/List/Slice/Slice.md
+++ b/courses/Rascal/Expressions/Values/List/Slice/Slice.md
@@ -47,16 +47,16 @@ The slice parameters `begin`, `end`, and `step` are determined as follows:
 
 *  _Exp~2~_:
 **  If _Exp~2~_ is absent, then `begin = 0`.
-**  Otherwise, if _N~2~_ >= 0 then `begin = min(N~2~, Len)` else `begin = max(N~2~ + Len, 0)`. 
+**  Otherwise, if _N~2~_ >= 0 then `begin = min(N~2~, Len-1)` else `begin = max(N~2~ + Len, 0)`. 
 *  _Exp~4~_:
 **  If _Exp~4~_ is absent, then `end = Len`.
-**  Otherwise, if _N~4~_ >= 0, then `end = min(N~4~, Len-1)` else `end = max(N~4~ + Len, 0)`.
+**  Otherwise, if _N~4~_ >= 0, then `end = min(N~4~, Len)` else `end = max(N~4~ + Len, 0)`.
 *  _Exp~3~_:
 **  If _Exp~3~_ is absent, then if `begin < end` then `step = 1` else `step = -1`.
 **  Otherwise, if `begin < end`, then `step = N~3~ - begin` else `step = begin - N~3~`.
 
 
-Now, the constraints `0 <= begin < Len` and `0 < end <= Len` should hold,
+Now, the constraints `0 <= begin < Len` and `0 <= end <= Len` should hold,
 otherwise the exception `IndexOutOfBounds` is thrown.
 
 The slice consists of the elements `L[begin]`, `L[begin+step]`, `L[end - step]`.

--- a/courses/Rascal/Expressions/Values/List/Slice/Slice.md
+++ b/courses/Rascal/Expressions/Values/List/Slice/Slice.md
@@ -47,16 +47,16 @@ The slice parameters `begin`, `end`, and `step` are determined as follows:
 
 *  _Exp~2~_:
 **  If _Exp~2~_ is absent, then `begin = 0`.
-**  Otherwise, if _N~2~_ >= 0 then `begin = N~2~` else `begin = N~2~ + Len`. 
+**  Otherwise, if _N~2~_ >= 0 then `begin = min(N~2~, Len)` else `begin = max(N~2~ + Len, 0)`. 
 *  _Exp~4~_:
 **  If _Exp~4~_ is absent, then `end = Len`.
-**  Otherwise, if _N~4~_ >= 0, then `end = N~4~` else `end = N~4~ + Len`.
+**  Otherwise, if _N~4~_ >= 0, then `end = min(N~4~, Len-1)` else `end = max(N~4~ + Len, 0)`.
 *  _Exp~3~_:
 **  If _Exp~3~_ is absent, then if `begin < end` then `step = 1` else `step = -1`.
 **  Otherwise, if `begin < end`, then `step = N~3~ - begin` else `step = begin - N~3~`.
 
 
-Now, the constraints `0 <= begin < Len` and `0 < end < Len` should hold,
+Now, the constraints `0 <= begin < Len` and `0 < end <= Len` should hold,
 otherwise the exception `IndexOutOfBounds` is thrown.
 
 The slice consists of the elements `L[begin]`, `L[begin+step]`, `L[end - step]`.
@@ -126,6 +126,8 @@ Slices not do go "out of bounds". Instead they just stop at the end or beginning
 ```rascal-shell,continue
 L[..10];
 L[..-11];
+L[-12..12];
+L[10..-10];
 ```
 
 


### PR DESCRIPTION
This change is linked to [this issue](https://github.com/usethesource/rascal/issues/2370#issuecomment-3228210108)
The implementation is defined in [this PR](https://github.com/usethesource/rascal/pull/2588)

The goal is to provide clear semantic for "out of bound" as stated at the end of examples : 
> Slices not do go "out of bounds". Instead they just stop at the end or beginning

The constraint on `begin` and `end` were changed to allow all possible slicing.
With `L = [0,1,2,3,4,5,6,7,8,9];` :
| | Documentation | Rascal v0.41.3 |
|-|-|-|
|`L[0..0]`| `IndexOutOfBound` |`[]`|
|`L[..10]`| `IndexOutOfBound` |`[0,1,2,3,4,5,6,7,8,9]`|
|`L[10..10]`| `IndexOutOfBound` |`[]`|

This definition is compatible with the use of negative index, and with the min/max, the constraint should hold (which was not the case before).

